### PR TITLE
Relocate issue and redeem to the GiftCardService

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ trim_trailing_whitespace = true
 
 [*.json]
 indent_size = 2
+
+[*.md]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -38,6 +38,32 @@ $locations = $gifty->locations->all();
 $giftCard = $gifty->giftCards->get('ABCDABCDABCDABCD');
 ```
 
+### Issue a Gift Card
+
+```php
+$transaction = $gifty->giftCards->issue(
+  'ABCDABCDABCDABCD',
+  [
+    "amount" => 1250,
+    "currency" => "EUR",
+    "promotional" => false
+  ]
+);
+```
+
+### Redeem a Gift Card
+
+```php
+$transaction = $gifty->giftCards->redeem(
+  'ABCDABCDABCDABCD',
+  [
+    "amount" => 1250,
+    "currency" => "EUR",
+    "capture" => false
+  ]
+);
+```
+
 ### Retrieve all Transactions
 
 ```php
@@ -50,32 +76,6 @@ $transactions = $giftCard->transactions->all();
 ```php
 $giftCard = $gifty->giftCards->get('ABCDABCDABCDABCD');
 $transaction = $giftCard->transactions->get('tr_BV94pGgqRvgobxvrLX28jEl0');
-```
-
-### Issue a Gift Card
-
-```php
-$giftCard = $gifty->giftCards->get('ABCDABCDABCDABCD');
-$transaction = $giftCard->transactions->issue(
-  [
-    "amount" => 1250,
-    "currency" => "EUR",
-    "promotional" => false
-  ]
-);
-```
-
-### Redeem a Gift Card
-
-```php
-$giftCard = $gifty->giftCards->get('ABCDABCDABCDABCD');
-$transaction = $giftCard->transactions->redeem(
-  [
-    "amount" => 1250,
-    "currency" => "EUR",
-    "capture" => false
-  ]
-);
 ```
 
 ### Capture a Transaction

--- a/src/HttpClient/GiftyGuzzleHttpClient.php
+++ b/src/HttpClient/GiftyGuzzleHttpClient.php
@@ -24,6 +24,7 @@ final class GiftyGuzzleHttpClient implements GiftyHttpClientInterface
         $this->guzzleClient = new Client(
             [
                 'base_uri' => $endpoint,
+                RequestOptions::HTTP_ERRORS => false,
                 RequestOptions::TIMEOUT => $timeout,
                 RequestOptions::CONNECT_TIMEOUT => $connectionTimeout,
                 RequestOptions::HEADERS => $headers,

--- a/src/HttpClient/GiftyHttpClientInterface.php
+++ b/src/HttpClient/GiftyHttpClientInterface.php
@@ -2,6 +2,7 @@
 
 namespace Gifty\Client\HttpClient;
 
+use Gifty\Client\Exceptions\ApiException;
 use Psr\Http\Message\ResponseInterface;
 
 interface GiftyHttpClientInterface
@@ -33,6 +34,7 @@ interface GiftyHttpClientInterface
      * @param string $path
      * @param array<string, bool|int|string> $options
      * @return ResponseInterface
+     * @throws ApiException
      */
     public function request(string $method, string $path, array $options = []): ResponseInterface;
 }

--- a/src/Resources/GiftCard.php
+++ b/src/Resources/GiftCard.php
@@ -44,6 +44,14 @@ final class GiftCard extends AbstractResource
         $this->transactions = new TransactionService($httpClient, $this);
     }
 
+    public static function cleanCode(string $code): string
+    {
+        $code = str_replace(' ', '', $code);
+        $code = str_replace('-', '', $code);
+
+        return $code;
+    }
+
     public function getId(): ?string
     {
         return $this->container['id'];

--- a/src/Services/GiftCardService.php
+++ b/src/Services/GiftCardService.php
@@ -3,7 +3,9 @@
 namespace Gifty\Client\Services;
 
 use Gifty\Client\Exceptions\ApiException;
+use Gifty\Client\Exceptions\MissingParameterException;
 use Gifty\Client\Resources\GiftCard;
+use Gifty\Client\Resources\Transaction;
 
 final class GiftCardService extends AbstractService
 {
@@ -30,8 +32,41 @@ final class GiftCardService extends AbstractService
 
         $resource = $this->parseApiResponse($response);
         $resource['code'] = $id;
-        $resourceClass = $this->getResourceClassPath();
 
-        return new $resourceClass($this->httpClient, (array)$resource);
+        return new GiftCard($this->httpClient, (array)$resource);
+    }
+
+    /**
+     * @param string $id
+     * @param array<string,string|bool|int> $options
+     * @return Transaction
+     * @throws ApiException
+     * @throws MissingParameterException
+     */
+    public function redeem(string $id, array $options = []): Transaction
+    {
+        $id = GiftCard::cleanCode($id);
+        $path = $this->buildApiPath([$id, 'redeem']);
+        $response = $this->httpClient->request('POST', $path, $options);
+        $resource = $this->parseApiResponse($response);
+
+        return new Transaction($this->httpClient, (array)$resource);
+    }
+
+    /**
+     * @param string $id
+     * @param array<string,string|bool|int> $options
+     * @return Transaction
+     * @throws ApiException
+     * @throws MissingParameterException
+     */
+    public function issue(string $id, array $options = []): Transaction
+    {
+        $id = GiftCard::cleanCode($id);
+        $path = $this->buildApiPath([$id, 'issue']);
+        $response = $this->httpClient->request('POST', $path, $options);
+        $resource = $this->parseApiResponse($response);
+
+        return new Transaction($this->httpClient, (array)$resource);
     }
 }

--- a/src/Services/GiftCardService.php
+++ b/src/Services/GiftCardService.php
@@ -24,8 +24,7 @@ final class GiftCardService extends AbstractService
      */
     public function get(string $id): GiftCard
     {
-        $id = str_replace(' ', '', $id);
-        $id = str_replace('-', '', $id);
+        $id = GiftCard::cleanCode($id);
         $path = $this->buildApiPath([$id]);
         $response = $this->httpClient->request('GET', $path);
 

--- a/src/Services/TransactionService.php
+++ b/src/Services/TransactionService.php
@@ -40,34 +40,6 @@ final class TransactionService extends AbstractService
     }
 
     /**
-     * @param array<string,string|bool|int> $options
-     * @return Transaction
-     * @throws ApiException
-     */
-    public function redeem(array $options = []): Transaction
-    {
-        $path = $this->buildParentApiPath(['redeem']);
-        $response = $this->httpClient->request('POST', $path, $options);
-        $resources = $this->parseApiResponse($response);
-
-        return new Transaction($this->httpClient, (array)$resources);
-    }
-
-    /**
-     * @param array<string,string|bool|int> $options
-     * @return Transaction
-     * @throws ApiException
-     */
-    public function issue(array $options = []): Transaction
-    {
-        $path = $this->buildParentApiPath(['issue']);
-        $response = $this->httpClient->request('POST', $path, $options);
-        $resources = $this->parseApiResponse($response);
-
-        return new Transaction($this->httpClient, (array)$resources);
-    }
-
-    /**
      * @param string $transactionId
      * @param array<string,string|bool|int> $options
      * @return Transaction

--- a/tests/Common/GiftyMockHttpClient.php
+++ b/tests/Common/GiftyMockHttpClient.php
@@ -35,6 +35,7 @@ final class GiftyMockHttpClient implements GiftyHttpClientInterface
             [
                 'base_uri' => $endpoint,
                 'handler' => HandlerStack::create($this->mockHandler),
+                RequestOptions::HTTP_ERRORS => false,
                 RequestOptions::TIMEOUT => $timeout,
                 RequestOptions::CONNECT_TIMEOUT => $connectionTimeout,
                 RequestOptions::HEADERS => $headers,

--- a/tests/Services/GiftCardServiceTest.php
+++ b/tests/Services/GiftCardServiceTest.php
@@ -4,6 +4,7 @@ namespace Gifty\Client\Tests\Services;
 
 use Gifty\Client\Exceptions\ApiException;
 use Gifty\Client\Resources\GiftCard;
+use Gifty\Client\Resources\Transaction;
 use Gifty\Client\Services\GiftCardService;
 use Gifty\Client\Tests\Common\TestHelper;
 use GuzzleHttp\Psr7\Response;
@@ -23,7 +24,7 @@ final class GiftCardServiceTest extends TestCase
     public function testGiftCardGet(): void
     {
         // Arrange
-        $data = (string) file_get_contents('./tests/Data/GiftCards/Get.json');
+        $data = (string)file_get_contents('./tests/Data/GiftCards/Get.json');
         $this->httpClient->mockHandler->append(new Response(200, [], $data));
         $giftCardService = new GiftCardService($this->httpClient);
 
@@ -38,7 +39,7 @@ final class GiftCardServiceTest extends TestCase
     public function testGiftCardNotFound(): void
     {
         // Arrange
-        $data = (string) file_get_contents('./tests/Data/GiftCards/NotFound.json');
+        $data = (string)file_get_contents('./tests/Data/GiftCards/NotFound.json');
         $this->httpClient->mockHandler->append(new Response(404, [], $data));
         $giftCardService = new GiftCardService($this->httpClient);
 
@@ -49,5 +50,69 @@ final class GiftCardServiceTest extends TestCase
         // Act
         $giftCardCode = 'nonExistingCode';
         $giftCardService->get($giftCardCode);
+    }
+
+    public function testIssueGiftCard(): void
+    {
+        // Arrange
+        $transactionsData = (string)file_get_contents('./tests/Data/Transactions/Get.json');
+        $this->httpClient->mockHandler->append(new Response(200, [], $transactionsData));
+        $giftCardService = new GiftCardService($this->httpClient);
+
+        // Act
+        $transaction = $giftCardService->issue(
+            'giftCardCode',
+            [
+                "amount" => 1250,
+                "currency" => "EUR",
+                "promotional" => false
+            ]
+        );
+
+        // Assert
+        $this->assertInstanceOf(Transaction::class, $transaction);
+    }
+
+    public function testIssueGiftCardWithMissingParameter(): void
+    {
+        // Arrange
+        $transactionsData = (string)file_get_contents('./tests/Data/Transactions/ValidationError.json');
+        $this->httpClient->mockHandler->append(new Response(422, [], $transactionsData));
+        $giftCardService = new GiftCardService($this->httpClient);
+
+        // Assert
+        $this->expectException(ApiException::class);
+        $this->expectExceptionCode(422);
+        $this->expectExceptionMessage('The promotional field is required.');
+
+        // Act
+        $giftCardService->issue(
+            'giftCardCode',
+            [
+                "amount" => 1250,
+                "currency" => "EUR"
+            ]
+        );
+    }
+
+    public function testRedeemGiftCard(): void
+    {
+        // Arrange
+        $transactionsData = (string)file_get_contents('./tests/Data/Transactions/Get.json');
+        $this->httpClient->mockHandler->append(new Response(200, [], $transactionsData));
+        $giftCardService = new GiftCardService($this->httpClient);
+
+        // Act
+        $transaction = $giftCardService->redeem(
+            'giftCardCode',
+            [
+                "amount" => 1250,
+                "currency" => "EUR",
+                "capture" => false
+            ]
+        );
+
+        // Assert
+        $this->assertInstanceOf(Transaction::class, $transaction);
     }
 }

--- a/tests/Services/TransactionServiceTest.php
+++ b/tests/Services/TransactionServiceTest.php
@@ -68,67 +68,6 @@ final class TransactionServiceTest extends TestCase
         $giftCard->transactions->get("nonExistingTransactionId");
     }
 
-    public function testIssueGiftCard(): void
-    {
-        // Arrange
-        $transactionsData = (string) file_get_contents('./tests/Data/Transactions/Get.json');
-        $response = new Response(200, [], $transactionsData);
-        $giftCard = $this->buildGiftCardWithFollowUpResponse($response);
-
-        // Act
-        $transaction = $giftCard->transactions->issue(
-            [
-                "amount" => 1250,
-                "currency" => "EUR",
-                "promotional" => false
-            ]
-        );
-
-        // Assert
-        $this->assertInstanceOf(Transaction::class, $transaction);
-    }
-
-    public function testIssueGiftCardWithMissingParameter(): void
-    {
-        // Arrange
-        $transactionsData = (string) file_get_contents('./tests/Data/Transactions/ValidationError.json');
-        $response = new Response(200, [], $transactionsData);
-        $giftCard = $this->buildGiftCardWithFollowUpResponse($response);
-
-        // Assert
-        $this->expectException(ApiException::class);
-        $this->expectExceptionCode(422);
-        $this->expectDeprecationMessage('The promotional field is required.');
-
-        // Act
-        $giftCard->transactions->issue(
-            [
-                "amount" => 1250,
-                "currency" => "EUR"
-            ]
-        );
-    }
-
-    public function testRedeemGiftCard(): void
-    {
-        // Arrange
-        $transactionsData = (string) file_get_contents('./tests/Data/Transactions/Get.json');
-        $response = new Response(200, [], $transactionsData);
-        $giftCard = $this->buildGiftCardWithFollowUpResponse($response);
-
-        // Act
-        $transaction = $giftCard->transactions->redeem(
-            [
-                "amount" => 1250,
-                "currency" => "EUR",
-                "capture" => false
-            ]
-        );
-
-        // Assert
-        $this->assertInstanceOf(Transaction::class, $transaction);
-    }
-
     public function testCaptureTransaction(): void
     {
         // Arrange
@@ -156,7 +95,6 @@ final class TransactionServiceTest extends TestCase
         // Assert
         $this->assertInstanceOf(Transaction::class, $transaction);
     }
-
 
     private function buildGiftCardWithFollowUpResponse(Response $response): GiftCard
     {


### PR DESCRIPTION
The issue() and redeem() methods apply to a GiftCard and not to a Transaction. So, it makes more sense if you can call these methods directly from the GiftCardService.

This also removes the requirement of retrieving a GiftCard before a new issue or redeem action can be created, making integration more easy.