### PR TITLE
Update GiftyGuzzleHttpClient.php

### DIFF
--- a/src/HttpClient/GiftyGuzzleHttpClient.php
+++ b/src/HttpClient/GiftyGuzzleHttpClient.php
@@ -37,7 +37,15 @@ final class GiftyGuzzleHttpClient implements GiftyHttpClientInterface
      */
     public static function getClientName(): string
     {
-        return Utils::defaultUserAgent();
+        $version = 'undefined';
+
+        if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
+            $version = \GuzzleHttp\ClientInterface::MAJOR_VERSION;
+        } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+            $version = \GuzzleHttp\ClientInterface::VERSION;
+        }
+
+        return sprintf('GuzzleHttp/%d', $version);
     }
 
     /**

--- a/src/HttpClient/GiftyGuzzleHttpClient.php
+++ b/src/HttpClient/GiftyGuzzleHttpClient.php
@@ -6,7 +6,6 @@ use Gifty\Client\Exceptions\ApiException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
-use GuzzleHttp\Utils;
 use Psr\Http\Message\ResponseInterface;
 
 final class GiftyGuzzleHttpClient implements GiftyHttpClientInterface
@@ -40,9 +39,9 @@ final class GiftyGuzzleHttpClient implements GiftyHttpClientInterface
         $version = 'undefined';
 
         if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
-            $version = \GuzzleHttp\ClientInterface::MAJOR_VERSION;
+            $version = constant('\GuzzleHttp\ClientInterface::MAJOR_VERSION');
         } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
-            $version = \GuzzleHttp\ClientInterface::VERSION;
+            $version = constant('\GuzzleHttp\ClientInterface::VERSION');
         }
 
         return sprintf('GuzzleHttp/%d', $version);

--- a/tests/Common/GiftyMockHttpClient.php
+++ b/tests/Common/GiftyMockHttpClient.php
@@ -48,7 +48,15 @@ final class GiftyMockHttpClient implements GiftyHttpClientInterface
      */
     public static function getClientName(): string
     {
-        return Utils::defaultUserAgent();
+        $version = 'undefined';
+
+        if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
+            $version = constant('\GuzzleHttp\ClientInterface::MAJOR_VERSION');
+        } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+            $version = constant('\GuzzleHttp\ClientInterface::VERSION');
+        }
+
+        return sprintf('GuzzleHttp/%d', $version);
     }
 
     /**


### PR DESCRIPTION
The current Guzzle implementation can cause issues when a site also has the previous Guzzle 6 installed because of a renamed constant.