### PR TITLE
Allow setting custom HTTP headers

### DIFF
--- a/src/GiftyClient.php
+++ b/src/GiftyClient.php
@@ -30,6 +30,11 @@ final class GiftyClient
     private string $apiEndpoint = 'https://api.gifty.nl/v1/';
 
     /**
+     * @var array<string, string>
+     */
+    private array $apiHeaders = [];
+
+    /**
      * @var GiftyHttpClientInterface
      */
     private GiftyHttpClientInterface $httpClient;
@@ -49,6 +54,10 @@ final class GiftyClient
     {
         if (isset($options['api_endpoint'])) {
             $this->setApiEndpoint($options['api_endpoint']);
+        }
+
+        if (isset($options['api_headers']) && is_array($options['api_headers'])) {
+            $this->setApiHeaders($options['api_headers']);
         }
 
         $this->setHttpClient($httpClient);
@@ -98,10 +107,13 @@ final class GiftyClient
             $this->apiEndpoint,
             10,
             2,
-            [
+            array_merge(
+                [
                 'User-Agent' => $this->getUserAgent(GiftyHttpClient::getClientName()),
                 'Accept' => 'application/json',
-            ]
+                ],
+                $this->apiHeaders,
+            )
         );
 
         return $this;
@@ -110,6 +122,16 @@ final class GiftyClient
     private function setApiEndpoint(string $endpoint): self
     {
         $this->apiEndpoint = $endpoint;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    private function setApiHeaders(array $headers): self
+    {
+        $this->apiHeaders = $headers;
 
         return $this;
     }

--- a/src/GiftyClient.php
+++ b/src/GiftyClient.php
@@ -47,12 +47,12 @@ final class GiftyClient
     /**
      * GiftyClient constructor.
      * @param string $apiKey
-     * @param array<string, string> $options
+     * @param array<string, string|array<string, string>> $options
      * @param GiftyHttpClientInterface|null $httpClient
      */
     public function __construct(string $apiKey, array $options = [], ?GiftyHttpClientInterface $httpClient = null)
     {
-        if (isset($options['api_endpoint'])) {
+        if (isset($options['api_endpoint']) && is_string($options['api_endpoint'])) {
             $this->setApiEndpoint($options['api_endpoint']);
         }
 


### PR DESCRIPTION
It can be useful to pass different headers to the Gifty API. E.g. to pass the preferred language with the Accept-Language header.

This commit allows to pass custom headers via the $options parameter when initiating the GiftyClient. To do so, it is possible to pass 'api_headers' in the options array. See the example below.

```
$gifty = new \Gifty\Client\GiftyClient('eyJ0eXAi....', ['api_headers' => [
    'Accept-Language' => 'nl'
]]);
```