### PR TITLE
Release version 1.5.0

### DIFF
--- a/src/GiftyClient.php
+++ b/src/GiftyClient.php
@@ -21,7 +21,7 @@ use Gifty\Client\Services\TransactionService;
  */
 final class GiftyClient
 {
-    public const VERSION = '1.4.0';
+    public const VERSION = '1.5.0';
     private const USER_AGENT_FORMAT = 'Gifty/Gifty-PHP/%s/PHP/%s/%s';
 
     /**


### PR DESCRIPTION
* Add support for the gift card extend endpoint To extend the validity of a gift card after it has expired, an extend transaction can be made using the new extend endpoint.

```
$transaction = $gifty->giftCards->extend(
  'ABCDABCDABCDABCD',
  [
    "expires_at" => "2027-09-15T12:42:42+00:00"
  ]
);
```

* Add support for PHP 8.2