### PR TITLE
Release version 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ $locations = $gifty->locations->all();
 $packages = $gifty->packages->all();
 ```
 
+### Retrieve a Package
+
+```php
+$package = $gifty->packages->get('gp_ABCDABCD');
+```
+
 ### Retrieve a Gift Card
 
 ```php

--- a/src/GiftyClient.php
+++ b/src/GiftyClient.php
@@ -21,7 +21,7 @@ use Gifty\Client\Services\TransactionService;
  */
 final class GiftyClient
 {
-    public const VERSION = '1.5.0';
+    public const VERSION = '1.6.0';
     private const USER_AGENT_FORMAT = 'Gifty/Gifty-PHP/%s/PHP/%s/%s';
 
     /**

--- a/src/Resources/GiftCard.php
+++ b/src/Resources/GiftCard.php
@@ -40,6 +40,7 @@ final class GiftCard extends AbstractResource
         $this->container['balance'] = $data['balance'] ?? 0;
         $this->container['currency'] = $data['currency'] ?? null;
         $this->container['promotional'] = $data['promotional'] ?? null;
+        $this->container['package_id'] = $data['package'] ?? null;
         $this->container['is_redeemable'] = $data['is_redeemable'] ?? false;
         $this->container['is_issuable'] = $data['is_issuable'] ?? false;
         $this->container['is_extendable'] = $data['is_extendable'] ?? false;
@@ -77,6 +78,15 @@ final class GiftCard extends AbstractResource
         }
 
         return boolval($this->container['promotional']);
+    }
+
+    public function getPackageId(): ?string
+    {
+        if ($this->container['package_id'] === null) {
+            return null;
+        }
+
+        return strval($this->container['package_id']);
     }
 
     public function getExpiresAt(): ?string

--- a/src/Services/PackageService.php
+++ b/src/Services/PackageService.php
@@ -5,6 +5,7 @@ namespace Gifty\Client\Services;
 use Gifty\Client\Resources\Collection;
 use Gifty\Client\Resources\Package;
 use Gifty\Client\Services\Operation\All;
+use Gifty\Client\Services\Operation\Get;
 
 /**
  * Class PackageService
@@ -14,6 +15,7 @@ use Gifty\Client\Services\Operation\All;
 final class PackageService extends AbstractService
 {
     use All;
+    use Get;
 
     protected const API_PATH = 'packages';
 

--- a/tests/Data/Packages/Get.json
+++ b/tests/Data/Packages/Get.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "id": "gp_WxBZ9wp4ov6Da1d1rgjal6Dk",
+    "title": "Lunch for 2",
+    "description": "Lunch for 2, drinks excluded.",
+    "amount": 5950,
+    "currency": "EUR",
+    "active": false
+  }
+}

--- a/tests/Resources/GiftCardTest.php
+++ b/tests/Resources/GiftCardTest.php
@@ -44,6 +44,7 @@ final class GiftCardTest extends TestCase
         $balance = $giftCard->getBalance();
         $currency = $giftCard->getCurrency();
         $promotional = $giftCard->getPromotional();
+        $packageId = $giftCard->getPackageId();
         $created_at = $giftCard->getCreatedAt();
         $expires_at = $giftCard->getExpiresAt();
         $is_redeemable = $giftCard->isRedeemable();
@@ -56,6 +57,7 @@ final class GiftCardTest extends TestCase
         $this->assertSame($expectedOutput['balance'], $balance);
         $this->assertSame($expectedOutput['currency'], $currency);
         $this->assertSame($expectedOutput['promotional'], $promotional);
+        $this->assertSame($expectedOutput['package_id'], $packageId);
         $this->assertSame($expectedOutput['created_at'], $created_at);
         $this->assertSame($expectedOutput['expires_at'], $expires_at);
         $this->assertSame($expectedOutput['is_redeemable'], $is_redeemable);
@@ -88,6 +90,7 @@ final class GiftCardTest extends TestCase
                     'balance' => 1250,
                     'currency' => 'EUR',
                     'promotional' => false,
+                    'package' => null,
                     'is_redeemable' => true,
                     'is_issuable' => false,
                     'is_extendable' => false,
@@ -100,6 +103,7 @@ final class GiftCardTest extends TestCase
                     'balance' => 1250,
                     'currency' => 'EUR',
                     'promotional' => false,
+                    'package_id' => null,
                     'is_redeemable' => true,
                     'is_issuable' => false,
                     'is_extendable' => false,
@@ -114,6 +118,7 @@ final class GiftCardTest extends TestCase
                     'balance' => null,
                     'currency' => 'EUR',
                     'promotional' => true,
+                    'package' => 'gp_WxBZ9wp4ov6Da1d1rgjal6Dk',
                     'is_redeemable' => false,
                     'is_issuable' => true,
                     'is_extendable' => true,
@@ -126,6 +131,7 @@ final class GiftCardTest extends TestCase
                     'balance' => 0,
                     'currency' => 'EUR',
                     'promotional' => true,
+                    'package_id' => 'gp_WxBZ9wp4ov6Da1d1rgjal6Dk',
                     'is_redeemable' => false,
                     'is_issuable' => true,
                     'is_extendable' => true,
@@ -144,6 +150,7 @@ final class GiftCardTest extends TestCase
                     'balance' => 0,
                     'currency' => null,
                     'promotional' => null,
+                    'package_id' => null,
                     'is_redeemable' => false,
                     'is_issuable' => false,
                     'is_extendable' => false,

--- a/tests/Services/PackageServiceTest.php
+++ b/tests/Services/PackageServiceTest.php
@@ -47,4 +47,19 @@ final class PackageServiceTest extends TestCase
         $this->assertInstanceOf(Collection::class, $packages);
         $this->assertContainsOnlyInstancesOf(Package::class, $packages);
     }
+
+    public function testPackageGet(): void
+    {
+        // Arrange
+        $packagesData = (string) file_get_contents('./tests/Data/Packages/Get.json');
+        $response = new Response(200, [], $packagesData);
+        $this->httpClient->mockHandler->append($response);
+
+        // Act
+        $packageService = new PackageService($this->httpClient);
+        $package = $packageService->get("packageId");
+
+        // Assert
+        $this->assertInstanceOf(Package::class, $package);
+    }
 }


### PR DESCRIPTION
* Add support for the get package endpoint To retrieve a single package, the get package endpoint can be used to retrieve a single package by its ID.

$package = $gifty->packages->get('gp_ABCDABCD');